### PR TITLE
import fix

### DIFF
--- a/packages/store/src/field_layout.fe
+++ b/packages/store/src/field_layout.fe
@@ -1,5 +1,5 @@
 use std::evm
-use constants::{WORD_SIZE, WORD_LAST_INDEX, BYTE_TO_BITS, MAX_TOTAL_FIELDS, MAX_DYNAMIC_FIELDS}
+use ingot::constants::{WORD_SIZE, WORD_LAST_INDEX, BYTE_TO_BITS, MAX_TOTAL_FIELDS, MAX_DYNAMIC_FIELDS}
 
 struct FieldLayoutLib_InvalidLength {
     pub length: u256

--- a/packages/store/src/lib.fe
+++ b/packages/store/src/lib.fe
@@ -3,8 +3,6 @@ use std::evm
 use std::buf::{MemoryBuffer, MemoryBufferReader, MemoryBufferWriter}
 use store::{Store, StoreAccessor}
 
-use field_layout::{FieldLayout}
-
 // enum SchemaType {
 //     U8(u8)
 //     U16(u16)


### PR DESCRIPTION
fwir items in a module are loaded eagerly, which occasionally triggers cycles. line 6 in lib.fe was triggering this somehow, so for now I just removed it since the import wasnt being used